### PR TITLE
Add #[\AllowDynamicProperties] attribute to prevent deprecation warning.

### DIFF
--- a/DashboardPanel.class.php
+++ b/DashboardPanel.class.php
@@ -16,6 +16,8 @@ use function ProcessWire\__;
  * @author Philipp Daun <post@philippdaun.net>
  * @license GPL-3.0
  */
+
+#[\AllowDynamicProperties]
 abstract class DashboardPanel extends Wire implements Module
 {
     /**


### PR DESCRIPTION
https://stitcher.io/blog/deprecated-dynamic-properties-in-php-82